### PR TITLE
Initialize gRPC pool lazy

### DIFF
--- a/app/component/grpc_pool.go
+++ b/app/component/grpc_pool.go
@@ -12,14 +12,18 @@ type Grpc interface {
 
 func newGrpc(config *system.Config) Grpc {
 	return &grpc{
-		pool: repo.NewGrpcPool(config.GetDgraphURL()),
+		config: config,
 	}
 }
 
 type grpc struct {
-	pool repo.GrpcPool
+	config *system.Config
+	pool   repo.GrpcPool
 }
 
 func (g *grpc) GetDgraphPool() repo.GrpcPool {
+	if g.pool == nil {
+		g.pool = repo.NewGrpcPool(g.config.GetDgraphURL())
+	}
 	return g.pool
 }

--- a/infra/repo/grpc_pool.go
+++ b/infra/repo/grpc_pool.go
@@ -28,6 +28,7 @@ type grpcPool struct {
 }
 
 func (p *grpcPool) Get() (*grpc.ClientConn, error) {
+	log.Debug("Dial gRPC connection", "addr", p.url)
 	return grpc.Dial(p.url, dialOptions()...)
 }
 


### PR DESCRIPTION
## WHY

since #8 , `GrpcPool.url` will be nil

## WHAT
initialize `GrpcPool` lazy
